### PR TITLE
bootstrap game creation to open firefox midgame as an arbitrary player

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,12 +19,13 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.23.x'
+        go-version: 'stable'
 
     - name: Test
       run: bin/test -v
 
     # all updated sqlc definitions should be committed
+    - uses: actions/checkout@v4
     - uses: stefanzweifel/git-auto-commit-action@v6
       with:
         commit_message: "automated sqlc updates"

--- a/bin/mock
+++ b/bin/mock
@@ -175,6 +175,7 @@ done
 echo "starting game $GAME_ID"
 request "POST" "/$GAME_ID/action/start" "-b $HOST_COOKIE"
 
+# opens the game in a new private firefox window with the cookie of the provided player
 open_in_firefox "http://localhost:7777/$GAME_ID" "$(cookie_file "${PLAYERS[1]}")"
 
 # echo "first spin"


### PR DESCRIPTION
`bin/mock` will 
- create a new game on a localhost:7777 server
- join as host
- join as multiple players
- start the game
- *open firefox to localhost:7777* as an arbitrary player/host

...I also fixed the test script which was failing to commit because I hadn't checked out the repo first. :facepalm: 