### PR TITLE
prevent re-join problems

### DIFF
--- a/bin/db-dev
+++ b/bin/db-dev
@@ -60,11 +60,11 @@ fi
 # wait for ready
 printf "waiting for %s to be ready..." ${CONTAINER}
 for _ in $(seq 1 30); do
-  if docker exec "$CONTAINER" pg_isready -U "$USER" >/dev/null 2>&1; then
+  if docker exec "$CONTAINER" pg_isready -h 127.0.0.1 -p 5432 -U "$USER" -d "$DB" >/dev/null 2>&1; then
     printf "\n"
     mkdir -p "/tmp/rulette"
     touch "/tmp/rulette/db-ready"
-    trap "rm -f /tmp/rulette/db-ready" EXIT
+    trap 'rm -f /tmp/rulette/db-ready; cleanup' EXIT
     echo "${CONTAINER} ready on :${PORT}"
     echo
     echo "ctrl-c to stop"

--- a/pregame.go
+++ b/pregame.go
@@ -104,6 +104,18 @@ func joinHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	switch r.Method {
 	case http.MethodGet:
+		// if the visitor is already a player in this game, don't show them
+		// the join form — bounce them back to the game page.
+		if _, cookieKey, err := cookie(r); err == nil {
+			s, err := stateFromCacheOrDB(r.Context(), &cache, gameID)
+			if err == nil && s.isPlayerInGame(cookieKey) {
+				log.Warn("player attempted to rejoin, redirecting to game",
+					"game_id", gameID,
+				)
+				http.Redirect(w, r, fmt.Sprintf("/%s", gameID), http.StatusSeeOther)
+				return
+			}
+		}
 		w.Header().Set("Content-Type", "text/html")
 		templateFilepath := path.Join("static", "html", "tmpl.join.html")
 		tmpl, err := readParse(static, templateFilepath)

--- a/pregame.go
+++ b/pregame.go
@@ -105,10 +105,20 @@ func joinHandler(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
 		// if the visitor is already a player in this game, don't show them
-		// the join form — bounce them back to the game page.
+		// the join form — bounce them back to the game page. Fail closed
+		// on state lookup errors: a cookied visitor reaching the form is
+		// the bug we're trying to prevent.
 		if _, cookieKey, err := cookie(r); err == nil {
 			s, err := stateFromCacheOrDB(r.Context(), &cache, gameID)
-			if err == nil && s.isPlayerInGame(cookieKey) {
+			if err != nil {
+				log.Error("fetch game state for rejoin check",
+					"error", err,
+					"game_id", gameID,
+				)
+				http.Error(w, "internal server error", http.StatusInternalServerError)
+				return
+			}
+			if s.isPlayerInGame(cookieKey) {
 				log.Warn("player attempted to rejoin, redirecting to game",
 					"game_id", gameID,
 				)
@@ -145,6 +155,28 @@ func joinHandler(w http.ResponseWriter, r *http.Request) {
 		if username == "" {
 			http.Error(w, "missing required field: username", http.StatusBadRequest)
 			return
+		}
+
+		// reject rejoin: if the caller already has a session for this game,
+		// bounce to the game page rather than minting a new player/session
+		// (which would orphan the original identity and host initiative).
+		if _, cookieKey, err := cookie(r); err == nil {
+			s, err := stateFromCacheOrDB(r.Context(), &cache, gameID)
+			if err != nil {
+				log.Error("fetch game state for rejoin check",
+					"error", err,
+					"game_id", gameID,
+				)
+				http.Error(w, "internal server error", http.StatusInternalServerError)
+				return
+			}
+			if s.isPlayerInGame(cookieKey) {
+				log.Warn("POST rejoin blocked, redirecting to game",
+					"game_id", gameID,
+				)
+				http.Redirect(w, r, fmt.Sprintf("/%s", gameID), http.StatusSeeOther)
+				return
+			}
 		}
 
 		switch game.StateID {

--- a/rulette_test.go
+++ b/rulette_test.go
@@ -166,6 +166,38 @@ func TestGame(t *testing.T) {
 		)
 	})
 
+	t.Run("GET /{game_id}/join (existing player)", func(t *testing.T) {
+		req := httptest.NewRequest(
+			http.MethodGet, fmt.Sprintf("/%s/join", gameID), nil,
+		)
+		req.AddCookie(users[0].cookie)
+		w := httptest.NewRecorder()
+		joinHandler(w, req)
+		require.Equal(t, http.StatusSeeOther, w.Result().StatusCode,
+			"existing player GET /join should redirect",
+		)
+		require.Equal(t, fmt.Sprintf("/%s", gameID),
+			w.Result().Header.Get("Location"),
+			"redirect target should be the game page",
+		)
+		for _, c := range w.Result().Cookies() {
+			require.NotEqual(t, "session", c.Name,
+				"existing-player redirect must not issue a new session cookie",
+			)
+		}
+	})
+
+	t.Run("GET /{game_id}/join (no cookie)", func(t *testing.T) {
+		req := httptest.NewRequest(
+			http.MethodGet, fmt.Sprintf("/%s/join", gameID), nil,
+		)
+		w := httptest.NewRecorder()
+		joinHandler(w, req)
+		require.Equal(t, http.StatusOK, w.Result().StatusCode,
+			"strangers without a cookie should still get the join form",
+		)
+	})
+
 	t.Run("GET /{game_id}/qr (inviting)", func(t *testing.T) {
 		mux := http.NewServeMux()
 		mux.HandleFunc("/{game_id}/qr", qrHandler)


### PR DESCRIPTION
fixes issue where a joined host or participant -- if they clicked the "invite player" link meant for others -- would be given a join menu, and allowed to rejoin with a new name, and given a new cookie that wiped out their prior.

if they were the host, the game is now hostless and unstart-able.

Now, joining with a valid cookie, just redirects to the lobby.
