### PR TITLE
errors as popups

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: read
 
 jobs:
   release:
@@ -24,6 +25,8 @@ jobs:
 
       - name: Compute next tag
         id: tag
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           # Reuse an existing v* tag on HEAD if present — makes reruns
           # on the same commit idempotent (no orphan tags, no skipped
@@ -37,14 +40,24 @@ jobs:
           fi
           latest=$(git tag --list 'v*' --sort=-v:refname | head -n1)
           if [ -z "$latest" ]; then
-            next="v0.0.1"
-          else
-            IFS='.' read -r major minor patch <<< "${latest#v}"
-            next="v${major}.${minor}.$((patch + 1))"
+            latest="v0.0.0"
           fi
+          IFS='.' read -r major minor patch <<< "${latest#v}"
+          # A 'feature' label on the merged PR bumps the minor version
+          # (zeroing the patch), otherwise the patch is bumped. The default
+          # token reads the labels via the pull-requests: read permission;
+          # a direct push with no PR falls back to a patch bump.
+          labels=$(gh api "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/pulls" \
+            --jq '.[].labels[].name' 2>/dev/null || true)
+          if echo "$labels" | grep -qx 'feature'; then
+            minor=$((minor + 1)); patch=0
+          else
+            patch=$((patch + 1))
+          fi
+          next="v${major}.${minor}.${patch}"
           echo "next=$next" >> "$GITHUB_OUTPUT"
           echo "reuse=false" >> "$GITHUB_OUTPUT"
-          echo "Next tag: $next"
+          echo "Next tag: $next (labels: $(echo "$labels" | paste -sd, -))"
 
       - name: Build binaries
         env:

--- a/actions.go
+++ b/actions.go
@@ -85,6 +85,7 @@ func actionHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	span.SetAttributes(attrPlayerID.String(cookieID))
+	log = log.With("cookie_id", cookieID)
 	state, err := stateFromCacheOrDB(r.Context(), &cache, gameID)
 	if err != nil {
 		if err == ErrStateNoGame {
@@ -97,11 +98,7 @@ func actionHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if !state.isPlayerInGame(cookieKey) {
-		log.Warn(
-			"prohibiting unauthorized player access",
-			"cookie_key", cookieKey,
-			"cookie_id", cookieID,
-		)
+		log.Warn("prohibiting unauthorized player access")
 		http.Error(w, "player not in game", http.StatusForbidden)
 		return
 	}
@@ -248,9 +245,7 @@ func actionHandler(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			if !state.isPlayerTurn(cookieKey) {
-				log.Warn("prohibiting non-turn player from spinning",
-					"cookie_id", cookieID,
-				)
+				log.Warn("prohibiting non-turn player from spinning")
 				http.Error(w, "not your turn", http.StatusForbidden)
 				return
 			}
@@ -488,9 +483,7 @@ func actionHandler(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			if !state.isPlayerTurn(cookieKey) {
-				log.Warn("prohibiting non-turn player from acknowledging",
-					"cookie_id", cookieID,
-				)
+				log.Warn("prohibiting non-turn player from acknowledging")
 				http.Error(w, "not your turn", http.StatusForbidden)
 				return
 			}
@@ -722,10 +715,7 @@ func actionHandler(w http.ResponseWriter, r *http.Request) {
 
 		case "flip":
 			if !state.isPlayerTurn(cookieKey) {
-				log.Warn("prohibiting non-turn player from flipping",
-					"game_id", gameID,
-					"cookie_id", cookieID,
-				)
+				log.Warn("prohibiting non-turn player from flipping")
 				http.Error(w, "not your turn", http.StatusForbidden)
 				return
 			}
@@ -869,10 +859,7 @@ func actionHandler(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		case "shred":
 			if !state.isPlayerTurn(cookieKey) {
-				log.Warn("prohibiting non-turn player from shredding",
-					"game_id", gameID,
-					"cookie_id", cookieID,
-				)
+				log.Warn("prohibiting non-turn player from shredding")
 				http.Error(w, "not your turn", http.StatusForbidden)
 				return
 			}
@@ -1018,10 +1005,7 @@ func actionHandler(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		case "clone":
 			if !state.isPlayerTurn(cookieKey) {
-				log.Warn("prohibiting non-turn player from cloning",
-					"game_id", gameID,
-					"cookie_id", cookieID,
-				)
+				log.Warn("prohibiting non-turn player from cloning")
 				http.Error(w, "not your turn", http.StatusForbidden)
 				return
 			}
@@ -1203,10 +1187,7 @@ func actionHandler(w http.ResponseWriter, r *http.Request) {
 
 		case "transfer":
 			if !state.isPlayerTurn(cookieKey) {
-				log.Warn("prohibiting non-turn player from transferring",
-					"game_id", gameID,
-					"cookie_id", cookieID,
-				)
+				log.Warn("prohibiting non-turn player from transferring")
 				http.Error(w, "not your turn", http.StatusForbidden)
 				return
 			}

--- a/game.go
+++ b/game.go
@@ -89,7 +89,6 @@ func gameHandler(w http.ResponseWriter, r *http.Request) {
 	if !state.isPlayerInGame(cookieKey) {
 		log.Warn(
 			"prohibiting unauthorized player access",
-			"cookie_key", cookieKey,
 			"cookie_id", cookieID,
 		)
 		span.SetAttributes(attrAlert.String("not-member"))
@@ -161,7 +160,6 @@ func dataHandler(w http.ResponseWriter, r *http.Request) {
 	if !state.isPlayerInGame(cookieKey) {
 		log.Warn(
 			"prohibiting unauthorized player access",
-			"cookie_key", cookieKey,
 			"cookie_id", cookieID,
 		)
 		http.Error(w, "player not in game", http.StatusForbidden)

--- a/game.go
+++ b/game.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	sqlc "github.com/grackleclub/rulette/db/sqlc"
+	semconv "go.opentelemetry.io/otel/semconv/v1.32.0"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -61,16 +62,23 @@ func gameHandler(w http.ResponseWriter, r *http.Request) {
 
 	cookieID, cookieKey, err := cookie(r)
 	if err != nil {
-		// no/invalid session means this visitor hasn't joined yet: send them
-		// to the game's join page rather than a raw error.
-		if err == ErrCookieMissing || err == ErrCookieInvalid {
-			log.Debug("no session for game page, redirecting to join", "error", err)
-			span.SetAttributes(attrAlert.String("no-session"))
-			http.Redirect(w, r, fmt.Sprintf("/%s/join", gameID), http.StatusSeeOther)
+		switch err {
+		case ErrCookieMissing:
+			// visitor simply hasn't joined yet: send them to the join page.
+			log.Debug("no session for game page, redirecting to join")
+		case ErrCookieInvalid:
+			// a malformed or tampered cookie is a user mistake or abuse path.
+			log.Warn("redirecting visitor to join, invalid session cookie", "error", err)
+		default:
+			log.Error("unexpected error getting cookie", "error", err)
+			redirectAlert(w, r, alertError)
 			return
 		}
-		log.Error("unexpected error getting cookie", "error", err)
-		redirectAlert(w, r, "error")
+		span.SetAttributes(
+			attrAlert.String(alertNoSession),
+			semconv.ErrorMessage(err.Error()),
+		)
+		http.Redirect(w, r, fmt.Sprintf("/%s/join", gameID), http.StatusSeeOther)
 		return
 	}
 	span.SetAttributes(attrPlayerID.String(cookieID))
@@ -79,26 +87,25 @@ func gameHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		if err == ErrStateNoGame {
 			log.Warn("game not found", "game_id", gameID)
-			redirectAlert(w, r, "not-found")
+			redirectAlert(w, r, alertNotFound)
 			return
 		}
 		log.Error("unexpected error fetching game state", "error", err)
-		redirectAlert(w, r, "error")
+		redirectAlert(w, r, alertError)
 		return
 	}
 	if !state.isPlayerInGame(cookieKey) {
-		log.Warn(
-			"prohibiting unauthorized player access",
+		log.Warn("prohibiting unauthorized player access",
 			"cookie_id", cookieID,
 		)
-		span.SetAttributes(attrAlert.String("not-member"))
+		span.SetAttributes(attrAlert.String(alertNotMember))
 		http.Redirect(w, r, fmt.Sprintf("/%s/join", gameID), http.StatusSeeOther)
 		return
 	}
 	err = state.callerInfo(cookieKey)
 	if err != nil {
 		log.Error("populate caller info", "error", err)
-		redirectAlert(w, r, "error")
+		redirectAlert(w, r, alertError)
 		return
 	}
 	span.SetAttributes(

--- a/game.go
+++ b/game.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"math"
 	"net/http"
 	"path"
@@ -60,7 +61,16 @@ func gameHandler(w http.ResponseWriter, r *http.Request) {
 
 	cookieID, cookieKey, err := cookie(r)
 	if err != nil {
-		setCookieErr(w, err)
+		// no/invalid session means this visitor hasn't joined yet: send them
+		// to the game's join page rather than a raw error.
+		if err == ErrCookieMissing || err == ErrCookieInvalid {
+			log.Debug("no session for game page, redirecting to join", "error", err)
+			span.SetAttributes(attrAlert.String("no-session"))
+			http.Redirect(w, r, fmt.Sprintf("/%s/join", gameID), http.StatusSeeOther)
+			return
+		}
+		log.Error("unexpected error getting cookie", "error", err)
+		redirectAlert(w, r, "error")
 		return
 	}
 	span.SetAttributes(attrPlayerID.String(cookieID))
@@ -69,11 +79,11 @@ func gameHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		if err == ErrStateNoGame {
 			log.Warn("game not found", "game_id", gameID)
-			http.Error(w, "game not found", http.StatusNotFound)
+			redirectAlert(w, r, "not-found")
 			return
 		}
 		log.Error("unexpected error fetching game state", "error", err)
-		http.Error(w, "internal server error", http.StatusInternalServerError)
+		redirectAlert(w, r, "error")
 		return
 	}
 	if !state.isPlayerInGame(cookieKey) {
@@ -82,13 +92,14 @@ func gameHandler(w http.ResponseWriter, r *http.Request) {
 			"cookie_key", cookieKey,
 			"cookie_id", cookieID,
 		)
-		http.Error(w, "player not in game", http.StatusForbidden)
+		span.SetAttributes(attrAlert.String("not-member"))
+		http.Redirect(w, r, fmt.Sprintf("/%s/join", gameID), http.StatusSeeOther)
 		return
 	}
 	err = state.callerInfo(cookieKey)
 	if err != nil {
 		log.Error("populate caller info", "error", err)
-		http.Error(w, "server error", http.StatusInternalServerError)
+		redirectAlert(w, r, "error")
 		return
 	}
 	span.SetAttributes(

--- a/game.go
+++ b/game.go
@@ -82,6 +82,7 @@ func gameHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	span.SetAttributes(attrPlayerID.String(cookieID))
+	log = log.With("cookie_id", cookieID)
 
 	state, err := stateFromCacheOrDB(r.Context(), &cache, gameID)
 	if err != nil {
@@ -95,9 +96,7 @@ func gameHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if !state.isPlayerInGame(cookieKey) {
-		log.Warn("prohibiting unauthorized player access",
-			"cookie_id", cookieID,
-		)
+		log.Warn("prohibiting unauthorized player access")
 		span.SetAttributes(attrAlert.String(alertNotMember))
 		http.Redirect(w, r, fmt.Sprintf("/%s/join", gameID), http.StatusSeeOther)
 		return
@@ -153,6 +152,7 @@ func dataHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	span.SetAttributes(attrPlayerID.String(cookieID))
+	log = log.With("cookie_id", cookieID)
 	state, err := stateFromCacheOrDB(r.Context(), &cache, gameID)
 	if err != nil {
 		if err == ErrStateNoGame {
@@ -165,10 +165,7 @@ func dataHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if !state.isPlayerInGame(cookieKey) {
-		log.Warn(
-			"prohibiting unauthorized player access",
-			"cookie_id", cookieID,
-		)
+		log.Warn("prohibiting unauthorized player access")
 		http.Error(w, "player not in game", http.StatusForbidden)
 		return
 	}

--- a/otel.go
+++ b/otel.go
@@ -34,6 +34,7 @@ var (
 	attrTopic      = attribute.Key("game.topic")
 	attrStateID    = attribute.Key("game.state_id")
 	attrCallerName = attribute.Key("game.caller_name")
+	attrAlert      = attribute.Key("game.alert")
 )
 
 var (

--- a/pregame.go
+++ b/pregame.go
@@ -41,10 +41,10 @@ func setCookieErr(w http.ResponseWriter, err error) {
 // copy shown on the destination page. Unknown or empty codes render no
 // popup. Shared by rootHandler and joinHandler's GET render.
 var alertMessages = map[string]string{
-	"in-progress": "Game cannot be joined, game already in progress.",
-	"over":        "That game is already over.",
-	"not-found":   "That game could not be found.",
-	"name-taken":  "That name is already taken — pick another.",
+	"in-progress": "Game in progress cannot be joined.",
+	"over":        "Game over.",
+	"not-found":   "Game does not exist.",
+	"name-taken":  "Name taken, choose another.",
 	"error":       "Server error, please try again.",
 }
 

--- a/pregame.go
+++ b/pregame.go
@@ -11,6 +11,7 @@ import (
 
 	sqlc "github.com/grackleclub/rulette/db/sqlc"
 	"github.com/jackc/pgx/v5/pgtype"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -36,11 +37,50 @@ func setCookieErr(w http.ResponseWriter, err error) {
 	}
 }
 
+// alertMessages maps the ?alert= code carried on a redirect to the popup
+// copy shown on the destination page. Unknown or empty codes render no
+// popup. Shared by rootHandler and joinHandler's GET render.
+var alertMessages = map[string]string{
+	"in-progress": "Game cannot be joined, game already in progress.",
+	"over":        "That game is already over.",
+	"not-found":   "That game could not be found.",
+	"name-taken":  "That name is already taken — pick another.",
+	"error":       "Server error, please try again.",
+}
+
+// indexView is the data for index.html: just an optional popup message.
+type indexView struct {
+	Alert string
+}
+
+// joinView is the data for tmpl.join.html. The game state row is embedded so
+// the template's promoted fields (.ID, .StateName, ...) keep working, plus an
+// optional popup message.
+type joinView struct {
+	sqlc.GameStateRow
+	Alert string
+}
+
+// redirectAlert bounces a full-page visitor home with a popup. code is a
+// fixed slug, so it needs no escaping. every alert redirect is a 303, so the
+// HTTP status no longer tells these cases apart in traces -- the game.alert
+// attribute does. genuine server errors are also marked on the span so they
+// keep counting in error-rate metrics despite the 3xx status.
+func redirectAlert(w http.ResponseWriter, r *http.Request, code string) {
+	span := trace.SpanFromContext(r.Context())
+	span.SetAttributes(attrAlert.String(code))
+	if code == "error" {
+		span.SetStatus(codes.Error, "server error")
+	}
+	http.Redirect(w, r, "/?alert="+code, http.StatusSeeOther)
+}
+
 // rootHandler provides the initial welcome page (index.html),
 // from which a user can start a new game with a POST to /create.
 func rootHandler(w http.ResponseWriter, r *http.Request) {
 	indexPath := path.Join("static", "html", "index.html")
-	if err := renderPage(r.Context(), w, indexPath, baseURL(r), true, nil); err != nil {
+	data := indexView{Alert: alertMessages[r.URL.Query().Get("alert")]}
+	if err := renderPage(r.Context(), w, indexPath, baseURL(r), true, data); err != nil {
 		http.Error(w, "server error", http.StatusInternalServerError)
 		return
 	}
@@ -89,7 +129,7 @@ func joinHandler(w http.ResponseWriter, r *http.Request) {
 	game, err := queries.GameState(r.Context(), gameID)
 	if err != nil {
 		log.Warn("game not found", "error", err)
-		http.Error(w, "game not found", http.StatusNotFound)
+		redirectAlert(w, r, "not-found")
 		return
 	}
 	switch r.Method {
@@ -105,7 +145,7 @@ func joinHandler(w http.ResponseWriter, r *http.Request) {
 					"error", err,
 					"game_id", gameID,
 				)
-				http.Error(w, "internal server error", http.StatusInternalServerError)
+				redirectAlert(w, r, "error")
 				return
 			}
 			if s.isPlayerInGame(cookieKey) {
@@ -118,13 +158,14 @@ func joinHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		w.Header().Set("Content-Type", "text/html")
 		templateFilepath := path.Join("static", "html", "tmpl.join.html")
-		if err := renderPage(r.Context(), w, templateFilepath, baseURL(r), true, game); err != nil {
+		data := joinView{GameStateRow: game, Alert: alertMessages[r.URL.Query().Get("alert")]}
+		if err := renderPage(r.Context(), w, templateFilepath, baseURL(r), true, data); err != nil {
 			log.Error("render template",
 				"error", err,
 				"template", templateFilepath,
 				"game_id", gameID,
 			)
-			http.Error(w, "internal server error", http.StatusInternalServerError)
+			redirectAlert(w, r, "error")
 			return
 		}
 	case http.MethodPost:
@@ -145,7 +186,7 @@ func joinHandler(w http.ResponseWriter, r *http.Request) {
 					"error", err,
 					"game_id", gameID,
 				)
-				http.Error(w, "internal server error", http.StatusInternalServerError)
+				redirectAlert(w, r, "error")
 				return
 			}
 			if s.isPlayerInGame(cookieKey) {
@@ -160,7 +201,7 @@ func joinHandler(w http.ResponseWriter, r *http.Request) {
 		switch game.StateID {
 		case stateOver:
 			log.Warn("join attempt to closed game")
-			http.Error(w, "game over", http.StatusGone)
+			redirectAlert(w, r, "over")
 			return
 
 		case statePending, stateTurn, stateReady:
@@ -168,7 +209,7 @@ func joinHandler(w http.ResponseWriter, r *http.Request) {
 				"state_id", game.StateID,
 				"state_name", game.StateName,
 			)
-			http.Error(w, "game in progress", http.StatusConflict)
+			redirectAlert(w, r, "in-progress")
 			return
 		case stateInviting, stateCreated:
 			// first join updates state from 'created' to 'inviting'
@@ -184,7 +225,7 @@ func joinHandler(w http.ResponseWriter, r *http.Request) {
 				})
 				if err != nil {
 					log.Error("update game from created to inviting", "error", err)
-					http.Error(w, "internal server error", http.StatusInternalServerError)
+					redirectAlert(w, r, "error")
 					return
 				}
 			}
@@ -195,7 +236,7 @@ func joinHandler(w http.ResponseWriter, r *http.Request) {
 					"error", err,
 					"game_id", gameID,
 				)
-				http.Error(w, "internal server error", http.StatusInternalServerError)
+				redirectAlert(w, r, "error")
 				return
 			}
 			var initiativeMax int
@@ -209,18 +250,23 @@ func joinHandler(w http.ResponseWriter, r *http.Request) {
 				}
 				// enforce no duplicate player names
 				if player.Name == username {
-					log.Debug("player already exists in game",
+					log.Warn("player already exists in game",
 						"game_id", gameID,
 						"username", username,
 					)
-					http.Error(w, "player already exists in game", http.StatusConflict)
+					trace.SpanFromContext(r.Context()).
+						SetAttributes(attrAlert.String("name-taken"))
+					http.Redirect(w, r,
+						fmt.Sprintf("/%s/join?alert=name-taken", gameID),
+						http.StatusSeeOther,
+					)
 					return
 				}
 			}
 			id, err := queries.PlayerCreate(r.Context(), username)
 			if err != nil {
 				log.Error("create player", "error", err, "username", username)
-				http.Error(w, "username: bad request", http.StatusBadRequest)
+				redirectAlert(w, r, "error")
 				return
 			}
 			// generate session key for game player and add them to the game.
@@ -228,7 +274,7 @@ func joinHandler(w http.ResponseWriter, r *http.Request) {
 			_, err = rand.Read(secret)
 			if err != nil {
 				log.Error("make secret", "error", err)
-				http.Error(w, "internal server error", http.StatusInternalServerError)
+				redirectAlert(w, r, "error")
 				return
 			}
 			secretStr := hex.EncodeToString(secret)
@@ -244,6 +290,15 @@ func joinHandler(w http.ResponseWriter, r *http.Request) {
 				SessionKey: pgtype.Text{String: secretStr, Valid: true},
 				Initiative: initiative,
 			})
+			if err != nil {
+				log.Error("add player to game",
+					"error", err,
+					"game_id", gameID,
+					"player_id", id,
+				)
+				redirectAlert(w, r, "error")
+				return
+			}
 
 			// give the player their session cookie
 			http.SetCookie(w, &http.Cookie{

--- a/pregame.go
+++ b/pregame.go
@@ -37,15 +37,31 @@ func setCookieErr(w http.ResponseWriter, err error) {
 	}
 }
 
+// alert codes ride a redirect's ?alert= query (or just tag the trace via
+// game.alert). The popup codes key into alertMessages for their copy;
+// dialogs.js reads ?alert= generically to autoshow and strip it, so the
+// client needs no per-code literal -- keeping this list and alertMessages
+// in sync is what holds the contract.
+const (
+	alertInProgress = "in-progress"
+	alertOver       = "over"
+	alertNotFound   = "not-found"
+	alertNameTaken  = "name-taken"
+	alertError      = "error"
+	// session codes only tag the trace and redirect to join, no popup copy.
+	alertNoSession = "no-session"
+	alertNotMember = "not-member"
+)
+
 // alertMessages maps the ?alert= code carried on a redirect to the popup
 // copy shown on the destination page. Unknown or empty codes render no
 // popup. Shared by rootHandler and joinHandler's GET render.
 var alertMessages = map[string]string{
-	"in-progress": "Game in progress cannot be joined.",
-	"over":        "Game over.",
-	"not-found":   "Game does not exist.",
-	"name-taken":  "Name taken, choose another.",
-	"error":       "Server error, please try again.",
+	alertInProgress: "Game in progress cannot be joined.",
+	alertOver:       "Game over.",
+	alertNotFound:   "Game does not exist.",
+	alertNameTaken:  "Name taken, choose another.",
+	alertError:      "Server error, please try again.",
 }
 
 // indexView is the data for index.html: just an optional popup message.
@@ -69,7 +85,7 @@ type joinView struct {
 func redirectAlert(w http.ResponseWriter, r *http.Request, code string) {
 	span := trace.SpanFromContext(r.Context())
 	span.SetAttributes(attrAlert.String(code))
-	if code == "error" {
+	if code == alertError {
 		span.SetStatus(codes.Error, "server error")
 	}
 	http.Redirect(w, r, "/?alert="+code, http.StatusSeeOther)
@@ -103,7 +119,7 @@ func createHandler(w http.ResponseWriter, r *http.Request) {
 	})
 	if err != nil {
 		log.Error("create game", "error", err)
-		redirectAlert(w, r, "error")
+		redirectAlert(w, r, alertError)
 		return
 	}
 
@@ -129,7 +145,7 @@ func joinHandler(w http.ResponseWriter, r *http.Request) {
 	game, err := queries.GameState(r.Context(), gameID)
 	if err != nil {
 		log.Warn("game not found", "error", err)
-		redirectAlert(w, r, "not-found")
+		redirectAlert(w, r, alertNotFound)
 		return
 	}
 	switch r.Method {
@@ -145,7 +161,7 @@ func joinHandler(w http.ResponseWriter, r *http.Request) {
 					"error", err,
 					"game_id", gameID,
 				)
-				redirectAlert(w, r, "error")
+				redirectAlert(w, r, alertError)
 				return
 			}
 			if s.isPlayerInGame(cookieKey) {
@@ -156,6 +172,21 @@ func joinHandler(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		}
+		// only a game still gathering players is joinable; in-progress or
+		// finished games bounce home with a popup instead of a dead form, so
+		// an invite link to a started or over game says so on load.
+		if game.StateID != stateCreated && game.StateID != stateInviting {
+			code := alertInProgress
+			if game.StateID == stateOver {
+				code = alertOver
+			}
+			log.Warn("redirecting visitor home, game not joinable",
+				"state_id", game.StateID,
+				"state_name", game.StateName,
+			)
+			redirectAlert(w, r, code)
+			return
+		}
 		w.Header().Set("Content-Type", "text/html")
 		templateFilepath := path.Join("static", "html", "tmpl.join.html")
 		data := joinView{GameStateRow: game, Alert: alertMessages[r.URL.Query().Get("alert")]}
@@ -165,7 +196,7 @@ func joinHandler(w http.ResponseWriter, r *http.Request) {
 				"template", templateFilepath,
 				"game_id", gameID,
 			)
-			redirectAlert(w, r, "error")
+			redirectAlert(w, r, alertError)
 			return
 		}
 	case http.MethodPost:
@@ -186,7 +217,7 @@ func joinHandler(w http.ResponseWriter, r *http.Request) {
 					"error", err,
 					"game_id", gameID,
 				)
-				redirectAlert(w, r, "error")
+				redirectAlert(w, r, alertError)
 				return
 			}
 			if s.isPlayerInGame(cookieKey) {
@@ -201,7 +232,7 @@ func joinHandler(w http.ResponseWriter, r *http.Request) {
 		switch game.StateID {
 		case stateOver:
 			log.Warn("join attempt to closed game")
-			redirectAlert(w, r, "over")
+			redirectAlert(w, r, alertOver)
 			return
 
 		case statePending, stateTurn, stateReady:
@@ -209,7 +240,7 @@ func joinHandler(w http.ResponseWriter, r *http.Request) {
 				"state_id", game.StateID,
 				"state_name", game.StateName,
 			)
-			redirectAlert(w, r, "in-progress")
+			redirectAlert(w, r, alertInProgress)
 			return
 		case stateInviting, stateCreated:
 			// first join updates state from 'created' to 'inviting'
@@ -225,7 +256,7 @@ func joinHandler(w http.ResponseWriter, r *http.Request) {
 				})
 				if err != nil {
 					log.Error("update game from created to inviting", "error", err)
-					redirectAlert(w, r, "error")
+					redirectAlert(w, r, alertError)
 					return
 				}
 			}
@@ -236,7 +267,7 @@ func joinHandler(w http.ResponseWriter, r *http.Request) {
 					"error", err,
 					"game_id", gameID,
 				)
-				redirectAlert(w, r, "error")
+				redirectAlert(w, r, alertError)
 				return
 			}
 			var initiativeMax int
@@ -254,10 +285,9 @@ func joinHandler(w http.ResponseWriter, r *http.Request) {
 						"game_id", gameID,
 						"username", username,
 					)
-					trace.SpanFromContext(r.Context()).
-						SetAttributes(attrAlert.String("name-taken"))
+					trace.SpanFromContext(r.Context()).SetAttributes(attrAlert.String(alertNameTaken))
 					http.Redirect(w, r,
-						fmt.Sprintf("/%s/join?alert=name-taken", gameID),
+						fmt.Sprintf("/%s/join?alert=%s", gameID, alertNameTaken),
 						http.StatusSeeOther,
 					)
 					return
@@ -266,7 +296,7 @@ func joinHandler(w http.ResponseWriter, r *http.Request) {
 			id, err := queries.PlayerCreate(r.Context(), username)
 			if err != nil {
 				log.Error("create player", "error", err, "username", username)
-				redirectAlert(w, r, "error")
+				redirectAlert(w, r, alertError)
 				return
 			}
 			// generate session key for game player and add them to the game.
@@ -274,7 +304,7 @@ func joinHandler(w http.ResponseWriter, r *http.Request) {
 			_, err = rand.Read(secret)
 			if err != nil {
 				log.Error("make secret", "error", err)
-				redirectAlert(w, r, "error")
+				redirectAlert(w, r, alertError)
 				return
 			}
 			secretStr := hex.EncodeToString(secret)
@@ -296,7 +326,7 @@ func joinHandler(w http.ResponseWriter, r *http.Request) {
 					"game_id", gameID,
 					"player_id", id,
 				)
-				redirectAlert(w, r, "error")
+				redirectAlert(w, r, alertError)
 				return
 			}
 

--- a/pregame.go
+++ b/pregame.go
@@ -172,19 +172,31 @@ func joinHandler(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		}
-		// only a game still gathering players is joinable; in-progress or
-		// finished games bounce home with a popup instead of a dead form, so
-		// an invite link to a started or over game says so on load.
-		if game.StateID != stateCreated && game.StateID != stateInviting {
-			code := alertInProgress
-			if game.StateID == stateOver {
-				code = alertOver
-			}
-			log.Warn("redirecting visitor home, game not joinable",
+		// only a game still gathering players is joinable; for any other state
+		// bounce home with a popup instead of rendering a dead form, so an
+		// invite link to a started or over game says so on load.
+		switch game.StateID {
+		case stateCreated, stateInviting:
+			// joinable: fall through to render the form below.
+		case stateOver:
+			log.Warn("redirecting visitor home, game over")
+			redirectAlert(w, r, alertOver)
+			return
+		case stateReady, stateTurn, statePending, stateChallenge, stateEnding:
+			log.Warn("redirecting visitor home, game in progress",
 				"state_id", game.StateID,
 				"state_name", game.StateName,
 			)
-			redirectAlert(w, r, code)
+			redirectAlert(w, r, alertInProgress)
+			return
+		default:
+			// every defined state is handled above; reaching here means an
+			// unknown state id, which is a bug.
+			log.Error("unexpected game state on join page",
+				"state_id", game.StateID,
+				"state_name", game.StateName,
+			)
+			redirectAlert(w, r, alertError)
 			return
 		}
 		w.Header().Set("Content-Type", "text/html")
@@ -234,8 +246,7 @@ func joinHandler(w http.ResponseWriter, r *http.Request) {
 			log.Warn("join attempt to closed game")
 			redirectAlert(w, r, alertOver)
 			return
-
-		case statePending, stateTurn, stateReady:
+		case stateReady, stateTurn, statePending, stateChallenge, stateEnding:
 			log.Warn("join attempt to game in progress",
 				"state_id", game.StateID,
 				"state_name", game.StateName,
@@ -346,6 +357,15 @@ func joinHandler(w http.ResponseWriter, r *http.Request) {
 			// that doesn't yet know about their join.
 			cache.Delete(gameID)
 			http.Redirect(w, r, fmt.Sprintf("/%s", gameID), http.StatusSeeOther)
+		default:
+			// every defined state is handled above; reaching here means an
+			// unknown state id, which is a bug.
+			log.Error("unexpected game state on join",
+				"state_id", game.StateID,
+				"state_name", game.StateName,
+			)
+			redirectAlert(w, r, alertError)
+			return
 		}
 	default:
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)

--- a/pregame.go
+++ b/pregame.go
@@ -103,7 +103,7 @@ func createHandler(w http.ResponseWriter, r *http.Request) {
 	})
 	if err != nil {
 		log.Error("create game", "error", err)
-		http.Error(w, "bad request", http.StatusBadRequest)
+		redirectAlert(w, r, "error")
 		return
 	}
 

--- a/rulette_test.go
+++ b/rulette_test.go
@@ -158,8 +158,14 @@ func TestGame(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, u.String(), nil)
 		w := httptest.NewRecorder()
 		joinHandler(w, req)
-		require.Equal(t, http.StatusConflict, w.Result().StatusCode,
-			"should not be able to join game with duplicate username: %s", users[0].username,
+		// a duplicate name bounces back to the join page with a popup code
+		// rather than dead-ending on a raw 409.
+		require.Equal(t, http.StatusSeeOther, w.Result().StatusCode,
+			"duplicate username should redirect back to join: %s", users[0].username,
+		)
+		require.Equal(t, fmt.Sprintf("/%s/join?alert=name-taken", gameID),
+			w.Result().Header.Get("Location"),
+			"redirect target should be the join page with name-taken alert",
 		)
 	})
 

--- a/static.go
+++ b/static.go
@@ -38,16 +38,16 @@ func renderTemplate(ctx context.Context, w io.Writer, path string, data any) err
 // renderPage parses the named template (with the shared partials) and
 // executes it against data, writing to w. base is the absolute
 // "scheme://host" a template reads via {{ baseURL }} to build
-// link-preview links; pass "" when the template emits none. Set preview
-// when the template calls the link-preview partial, so its {{define}}
-// blocks are parsed; leave it false for fragments to skip that read.
-// Wraps the work in a "template.render" span tagged with the path so
-// handler traces show template time as a child span.
-func renderPage(ctx context.Context, w io.Writer, path, base string, preview bool, data any) error {
+// link-preview links; pass "" when the template emits none. Set fullPage
+// when rendering a full page, so the page-only partials (link-preview meta
+// tags and the notice popup) are parsed; leave it false for fragments to
+// skip that read. Wraps the work in a "template.render" span tagged with
+// the path so handler traces show template time as a child span.
+func renderPage(ctx context.Context, w io.Writer, path, base string, fullPage bool, data any) error {
 	_, span := otel.Tracer(otelScope).Start(ctx, "template.render")
 	defer span.End()
 	span.SetAttributes(attribute.String("template", path))
-	tmpl, err := readParse(static, path, base, preview)
+	tmpl, err := readParse(static, path, base, fullPage)
 	if err != nil {
 		return fmt.Errorf("read parse %q: %w", path, err)
 	}
@@ -59,9 +59,9 @@ func renderPage(ctx context.Context, w io.Writer, path, base string, preview boo
 
 // readParse reads a template from the embedded filesystem and parses it
 // together with the shared partials. base is exposed to the template as
-// {{ baseURL }}. When preview is set, the link-preview partials are
-// parsed too, so a full page can call them.
-func readParse(fs embed.FS, path, base string, preview bool) (*template.Template, error) {
+// {{ baseURL }}. When fullPage is set, the page-only partials (link-preview
+// meta tags and the notice popup) are parsed too, so a full page can call them.
+func readParse(fs embed.FS, path, base string, fullPage bool) (*template.Template, error) {
 	f, err := fs.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("read file %q from embed.FS: %w", path, err)
@@ -87,7 +87,7 @@ func readParse(fs embed.FS, path, base string, preview bool) (*template.Template
 		return nil, fmt.Errorf("parse template %q: %w", name, err)
 	}
 	partials := sharedPartials
-	if preview {
+	if fullPage {
 		partials = append(partials, pagePartials...)
 	}
 	for _, p := range partials {

--- a/static.go
+++ b/static.go
@@ -19,11 +19,13 @@ var sharedPartials = []string{
 	"static/html/tmpl.footer.html",
 }
 
-// previewPartials hold the link-preview meta tags (og:image and friends)
-// only full pages emit. They are parsed on demand, so the frequently
-// polled HTMX fragments don't read and parse them on every render.
-var previewPartials = []string{
+// pagePartials hold {{define}} blocks only full pages need: the link-preview
+// meta tags (og:image and friends) and the page-load notice popup. They are
+// parsed on demand, so the frequently polled HTMX fragments don't read and
+// parse them on every render.
+var pagePartials = []string{
 	"static/html/tmpl.preview.html",
+	"static/html/tmpl.notice.html",
 }
 
 // renderTemplate executes a template that needs no absolute base URL,
@@ -86,7 +88,7 @@ func readParse(fs embed.FS, path, base string, preview bool) (*template.Template
 	}
 	partials := sharedPartials
 	if preview {
-		partials = append(partials, previewPartials...)
+		partials = append(partials, pagePartials...)
 	}
 	for _, p := range partials {
 		b, err := fs.ReadFile(p)

--- a/static/html/index.html
+++ b/static/html/index.html
@@ -41,6 +41,8 @@
       </article>
     </div>
 
+    {{ template "notice" . }}
+
     {{ template "footer" . }}
   </body>
 </html>

--- a/static/html/tmpl.join.html
+++ b/static/html/tmpl.join.html
@@ -37,6 +37,9 @@
         </div>
       </article>
     </div>
+
+    {{ template "notice" . }}
+
     {{ template "footer" . }}
   </body>
 </html>

--- a/static/html/tmpl.notice.html
+++ b/static/html/tmpl.notice.html
@@ -1,0 +1,8 @@
+{{define "notice"}}{{ if .Alert }}
+<dialog id="notice-dialog" data-autoshow>
+  <div class="dialog-body stack stack-centered">
+    <p id="notice-message">{{ .Alert }}</p>
+    <button class="button" data-close-dialog="notice-dialog">ok</button>
+  </div>
+</dialog>
+{{ end }}{{end}}

--- a/static/html/tmpl.notice.html
+++ b/static/html/tmpl.notice.html
@@ -2,7 +2,7 @@
 <dialog id="notice-dialog" data-autoshow>
   <div class="dialog-body stack stack-centered">
     <p id="notice-message">{{ .Alert }}</p>
-    <button class="button" data-close-dialog="notice-dialog">ok</button>
+    <button class="button-teal" data-close-dialog="notice-dialog">ok</button>
   </div>
 </dialog>
 {{ end }}{{end}}

--- a/static/js/dialogs.js
+++ b/static/js/dialogs.js
@@ -75,6 +75,12 @@
   // the home and join pages after a redirect carrying ?alert=<code>.
   var autoshow = document.querySelector("dialog[data-autoshow]");
   if (autoshow && !autoshow.open) {
+    // showModal steals focus, so when the notice closes return focus to
+    // whatever the page wanted focused (the username field on the join page).
+    autoshow.addEventListener("close", function () {
+      var focusTarget = document.querySelector("[autofocus]");
+      if (focusTarget) focusTarget.focus();
+    });
     autoshow.showModal();
     // drop ?alert= so a refresh, back, or shared link doesn't re-pop the popup
     if (window.history.replaceState) {

--- a/static/js/dialogs.js
+++ b/static/js/dialogs.js
@@ -71,6 +71,40 @@
   }
   document.body.addEventListener("notice", showNotice);
 
+  // server-rendered notice shown on page load: <dialog data-autoshow>. used by
+  // the home and join pages after a redirect carrying ?alert=<code>.
+  var autoshow = document.querySelector("dialog[data-autoshow]");
+  if (autoshow && !autoshow.open) {
+    autoshow.showModal();
+    // drop ?alert= so a refresh, back, or shared link doesn't re-pop the popup
+    if (window.history.replaceState) {
+      var alertUrl = new URL(window.location.href);
+      alertUrl.searchParams.delete("alert");
+      window.history.replaceState({}, "", alertUrl);
+    }
+  }
+
+  // a user-initiated action (POST) that 500s: show a popup so they know it
+  // didn't take and can retry. we scope this deliberately:
+  //   - only htmx:responseError (a real 5xx response), never htmx:sendError --
+  //     a dropped connection / offline blip stays silent and the next poll
+  //     recovers on its own.
+  //   - only POST. a transient 500 on a background GET poll self-heals on the
+  //     next tick, so there's no point interrupting play with a modal for it.
+  // htmx doesn't swap on an error response, so the triggering button is still
+  // in the DOM: dismissing the popup leaves them able to click again.
+  document.body.addEventListener("htmx:responseError", function (e) {
+    var xhr = e.detail && e.detail.xhr;
+    if (!xhr || xhr.status < 500) return;
+    var cfg = e.detail.requestConfig;
+    if (!cfg || cfg.verb !== "post") return;
+    var dialog = document.getElementById("notice-dialog");
+    var message = document.getElementById("notice-message");
+    if (!dialog || !message) return;
+    message.textContent = "Server error, please try again.";
+    if (!dialog.open) dialog.showModal();
+  });
+
   // host tried to start with fewer than the recommended players: confirm first.
   // HX-Trigger {"confirmStart":""} -> the dialog's "continue" reposts start with
   // ?confirm=1 so the server proceeds.


### PR DESCRIPTION
No more raw text error messages. Now we give popup messages for errors, network failure, and bad attempted joins and creates, and redirect to home.
