### PR TITLE
Weight modifier cards so they're dealt more often

### DIFF
--- a/db/queries/game_cards.sql
+++ b/db/queries/game_cards.sql
@@ -1,21 +1,26 @@
 -- name: GameCardsInitGeneric :exec
+WITH dealt AS (
+    SELECT id
+    FROM cards
+    CROSS JOIN LATERAL generate_series(1, weight) -- one row per copy
+    WHERE generic IS TRUE
+    ORDER BY weight DESC, RANDOM() -- always deal the weighted cards, fill the rest at random
+    LIMIT (SELECT card_count FROM games WHERE games.id = $1)
+)
 INSERT INTO game_cards (
-    game_id, 
-    card_id, 
-    slot, 
-    stack, 
+    game_id,
+    card_id,
+    slot,
+    stack,
     player_id
 ) SELECT
     $1::text,
     id,
+    -- number the dealt cards so they spread evenly across the wheel slots
     ((ROW_NUMBER() OVER ()) % (SELECT wheel_slots FROM games WHERE games.id = $1)) + 1,
     NULL, -- unshuffled
     NULL -- unrevealed
-FROM cards
-CROSS JOIN LATERAL generate_series(1, weight) -- one row per copy
-WHERE generic IS TRUE
-ORDER BY weight DESC, RANDOM() -- always deal the weighted cards, fill the rest at random
-LIMIT (SELECT card_count FROM games WHERE games.id = $1);
+FROM dealt;
 
 -- shuffles stacks within a slot, leaving slot assignments unchanged
 -- name: GameCardsShuffle :exec

--- a/db/queries/game_cards.sql
+++ b/db/queries/game_cards.sql
@@ -7,12 +7,15 @@ INSERT INTO game_cards (
     player_id
 ) SELECT
     $1::text,
-    id, 
+    id,
     ((ROW_NUMBER() OVER ()) % (SELECT wheel_slots FROM games WHERE games.id = $1)) + 1,
     NULL, -- unshuffled
     NULL -- unrevealed
-FROM cards 
-WHERE generic IS TRUE LIMIT (SELECT card_count FROM games WHERE games.id = $1);
+FROM cards
+CROSS JOIN LATERAL generate_series(1, weight) -- one row per copy
+WHERE generic IS TRUE
+ORDER BY weight DESC, RANDOM() -- always deal the weighted cards, fill the rest at random
+LIMIT (SELECT card_count FROM games WHERE games.id = $1);
 
 -- shuffles stacks within a slot, leaving slot assignments unchanged
 -- name: GameCardsShuffle :exec

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -96,6 +96,7 @@ CREATE TABLE IF NOT EXISTS cards (
 	created TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
 	generic BOOLEAN DEFAULT FALSE,
 	modifier_effect TEXT,
+	weight INTEGER NOT NULL DEFAULT 1, -- how many copies to deal into a game
 	FOREIGN KEY (type) REFERENCES card_types(name) ON DELETE CASCADE,
 	FOREIGN KEY (modifier_effect) REFERENCES modifier_effects(name) ON DELETE SET NULL,
 	CONSTRAINT chk_modifier_effect CHECK (
@@ -103,6 +104,7 @@ CREATE TABLE IF NOT EXISTS cards (
 		OR (type != 'modifier' AND modifier_effect IS NULL)
 	)
 );
+ALTER TABLE cards ADD COLUMN IF NOT EXISTS weight INTEGER NOT NULL DEFAULT 1;
 DELETE FROM cards a USING cards b
 WHERE a.id > b.id AND a.front = b.front;
 CREATE UNIQUE INDEX IF NOT EXISTS cards_front_unique ON cards (front);
@@ -260,6 +262,9 @@ ON CONFLICT (front) DO UPDATE SET
 	type = EXCLUDED.type,
 	generic = EXCLUDED.generic,
 	modifier_effect = EXCLUDED.modifier_effect;
+
+-- deal two of each modifier card, so they show up more than other generics
+UPDATE cards SET weight = 2 WHERE generic IS TRUE AND modifier_effect IS NOT NULL;
 
 -- card_id lacks primary key to allow cloning within a game,
 CREATE TABLE IF NOT EXISTS game_cards (

--- a/db/sqlc/cards.sql.go
+++ b/db/sqlc/cards.sql.go
@@ -12,7 +12,7 @@ import (
 )
 
 const card = `-- name: Card :one
-SELECT id, type, front, back, creator, created, generic, modifier_effect FROM cards WHERE id = $1
+SELECT id, type, front, back, creator, created, generic, modifier_effect, weight FROM cards WHERE id = $1
 `
 
 func (q *Queries) Card(ctx context.Context, id int32) (Cards, error) {
@@ -27,6 +27,7 @@ func (q *Queries) Card(ctx context.Context, id int32) (Cards, error) {
 		&i.Created,
 		&i.Generic,
 		&i.ModifierEffect,
+		&i.Weight,
 	)
 	return i, err
 }

--- a/db/sqlc/game_cards.sql.go
+++ b/db/sqlc/game_cards.sql.go
@@ -96,12 +96,15 @@ INSERT INTO game_cards (
     player_id
 ) SELECT
     $1::text,
-    id, 
+    id,
     ((ROW_NUMBER() OVER ()) % (SELECT wheel_slots FROM games WHERE games.id = $1)) + 1,
     NULL, -- unshuffled
     NULL -- unrevealed
-FROM cards 
-WHERE generic IS TRUE LIMIT (SELECT card_count FROM games WHERE games.id = $1)
+FROM cards
+CROSS JOIN LATERAL generate_series(1, weight) -- one row per copy
+WHERE generic IS TRUE
+ORDER BY weight DESC, RANDOM() -- always deal the weighted cards, fill the rest at random
+LIMIT (SELECT card_count FROM games WHERE games.id = $1)
 `
 
 func (q *Queries) GameCardsInitGeneric(ctx context.Context, dollar_1 string) error {

--- a/db/sqlc/game_cards.sql.go
+++ b/db/sqlc/game_cards.sql.go
@@ -88,23 +88,28 @@ func (q *Queries) GameCardShred(ctx context.Context, arg GameCardShredParams) er
 }
 
 const gameCardsInitGeneric = `-- name: GameCardsInitGeneric :exec
+WITH dealt AS (
+    SELECT id
+    FROM cards
+    CROSS JOIN LATERAL generate_series(1, weight) -- one row per copy
+    WHERE generic IS TRUE
+    ORDER BY weight DESC, RANDOM() -- always deal the weighted cards, fill the rest at random
+    LIMIT (SELECT card_count FROM games WHERE games.id = $1)
+)
 INSERT INTO game_cards (
-    game_id, 
-    card_id, 
-    slot, 
-    stack, 
+    game_id,
+    card_id,
+    slot,
+    stack,
     player_id
 ) SELECT
     $1::text,
     id,
+    -- number the dealt cards so they spread evenly across the wheel slots
     ((ROW_NUMBER() OVER ()) % (SELECT wheel_slots FROM games WHERE games.id = $1)) + 1,
     NULL, -- unshuffled
     NULL -- unrevealed
-FROM cards
-CROSS JOIN LATERAL generate_series(1, weight) -- one row per copy
-WHERE generic IS TRUE
-ORDER BY weight DESC, RANDOM() -- always deal the weighted cards, fill the rest at random
-LIMIT (SELECT card_count FROM games WHERE games.id = $1)
+FROM dealt
 `
 
 func (q *Queries) GameCardsInitGeneric(ctx context.Context, dollar_1 string) error {

--- a/db/sqlc/models.go
+++ b/db/sqlc/models.go
@@ -22,6 +22,7 @@ type Cards struct {
 	Created        pgtype.Timestamp `json:"created"`
 	Generic        pgtype.Bool      `json:"generic"`
 	ModifierEffect pgtype.Text      `json:"modifier_effect"`
+	Weight         int32            `json:"weight"`
 }
 
 type EventLog struct {


### PR DESCRIPTION
Makes the modifier cards (flip, shred, clone, transfer) show up more often than other generic cards.

## Changes

- Add a `weight` column to `cards` (default 1), and set it to 2 for the four modifier cards.
- `GameCardsInitGeneric` expands each card into `weight` copies via `generate_series`, orders by weight so the modifiers are always dealt, then fills the rest of the deck at random.
- Slot numbering happens in an outer query over the already-dealt subset, so cards still spread evenly across the wheel (the "3 deep per slot" invariant) instead of being numbered before the random `LIMIT`.

The `weight` column is added both in the `CREATE TABLE` and via `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`, so fresh and existing databases both pick it up on startup.